### PR TITLE
v1.2.2: Filetypes and backups

### DIFF
--- a/cogs/bridge.py
+++ b/cogs/bridge.py
@@ -1487,10 +1487,11 @@ class Bridge(commands.Cog, name=':link: Bridge'):
         prs = {}
         restored = False
         if hasattr(self.bot, 'bridge'):
-            msgs = self.bot.bridge.bridged
-            prs = self.bot.bridge.prs
-            restored = self.bot.bridge.restored
-            del self.bot.bridge
+            if self.bot.bridge: # Avoid restoring if bridge is None
+                msgs = self.bot.bridge.bridged
+                prs = self.bot.bridge.prs
+                restored = self.bot.bridge.restored
+                del self.bot.bridge
         self.bot.bridge = UnifierBridge(self.bot,self.logger)
         self.bot.bridge.bridged = msgs
         self.bot.bridge.prs = prs

--- a/cogs/bridge.py
+++ b/cogs/bridge.py
@@ -1083,7 +1083,8 @@ class UnifierBridge:
                         continue
                 else:
                     if (not 'audio' in attachment.content_type and not 'video' in attachment.content_type and
-                            not 'image' in attachment.content_type) or attachment.size > 25000000:
+                            not 'image' in attachment.content_type and not 'text/plain' in attachment.content_type and
+                            self.bot.config['safe_filetypes']) or attachment.size > 25000000:
                         continue
                 size_total += attachment.size
                 if size_total > 25000000:

--- a/cogs/bridge.py
+++ b/cogs/bridge.py
@@ -1047,7 +1047,10 @@ class UnifierBridge:
                         try:
                             return await source_file.to_file(use_cached=True, spoiler=source_file.is_spoiler())
                         except:
-                            return await source_file.to_file(use_cached=True, spoiler=False)
+                            try:
+                                return await source_file.to_file(use_cached=True, spoiler=False)
+                            except:
+                                return await source_file.to_file(use_cached=False, spoiler=False)
                     elif source=='revolt':
                         filebytes = await source_file.read()
                         return discord.File(fp=BytesIO(filebytes), filename=source_file.filename)

--- a/cogs/bridge.py
+++ b/cogs/bridge.py
@@ -2408,11 +2408,11 @@ class Bridge(commands.Cog, name=':link: Bridge'):
                     multisend = False
 
         try:
-            pr_roomname = self.bot.db['posts_room']
+            pr_roomname = self.bot.config['posts_room']
         except:
             pr_roomname = self.bot.db['rooms'][list(self.bot.db['rooms'].keys())[self.bot.config['pr_room_index']]]
         try:
-            pr_ref_roomname = self.bot.db['posts_ref_room']
+            pr_ref_roomname = self.bot.config['posts_ref_room']
         except:
             pr_ref_roomname = self.bot.db['rooms'][list(self.bot.db['rooms'].keys())[self.bot.config['pr_ref_room_index']]]
         is_pr = roomname == pr_roomname and (self.bot.config['allow_prs'] or self.bot.config['allow_posts'])

--- a/config.json
+++ b/config.json
@@ -4,6 +4,8 @@
   "owner": 356456393491873795,
   "prefix": "u!",
   "ping": 0,
+  "periodic_backup": 0,
+  "safe_filetypes": true,
   "branch": "main",
   "repo": "https://github.com/UnifierHQ/unifier",
   "check_endpoint": "https://github.com/UnifierHQ/unifier-version.git",

--- a/update.json
+++ b/update.json
@@ -2,8 +2,8 @@
   "id": "system",
   "name": "System extensions",
   "description": "Unifier system extensions",
-  "version": "v1.2.0",
-  "release": 36,
+  "version": "v1.2.1",
+  "release": 39,
   "minimum": 0,
   "shutdown": false,
   "modules": [


### PR DESCRIPTION
**Checklist**
<!--
Please make sure all of the following applies to your issue.
-->
- [X] My code follows the repository code of conduct.
- [X] I have tested this code to make sure it works as intended.

**Details**
<!--
What did you change? What did you add? What did you fix? Tell
us here!
-->
Adds option to disable filetype restrictions and periodic message backups.

**Tests**
<!--
Attach any evidence of your tests here, so we can see how well
it works.
-->
Python files can be bridged with safe filetypes off, and message can be identified even after an abrupt shutdown.
<img width="679" alt="image" src="https://github.com/UnifierHQ/unifier/assets/41323182/1d7817b7-f423-46f9-aeff-0e0fe1a22b09">

**Relevant issues**
<!--
Does this solve an issue? If yes, mention it here.
To mention an issue, type #[issue number], e.g. #1
-->
#99, #101